### PR TITLE
Allow networking to work properly by matching the kernel version to the RaspiOS version

### DIFF
--- a/native-emulation/install.sh
+++ b/native-emulation/install.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-readonly IMAGE='2020-02-13-raspbian-buster-lite'
+readonly IMAGE='2020-08-20-raspios-buster-armhf-lite'
 readonly KERNEL='kernel8.img'
 readonly PTB='bcm2710-rpi-3-b-plus.dtb'
 
@@ -13,7 +13,7 @@ readonly PTB_FILE="${TMP_DIR}/${PTB}"
 # commit hash to use for the https://github.com/dhruvvyas90/qemu-rpi-kernel/ repo:
 readonly COMMIT_HASH='c522bff346bb7401ad0b979778c23be52089618f'
 
-readonly IMAGE_URL="https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2020-02-14/${IMAGE}.zip"
+readonly IMAGE_URL="https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2020-08-24/${IMAGE}.zip"
 readonly KERNEL_URL="https://github.com/dhruvvyas90/qemu-rpi-kernel/blob/${COMMIT_HASH}/native-emulation/5.4.51%20kernels/${KERNEL}?raw=true"
 readonly PTB_URL="https://github.com/dhruvvyas90/qemu-rpi-kernel/blob/${COMMIT_HASH}/native-emulation/dtbs/${PTB}?raw=true"
 

--- a/native-emulation/install.sh
+++ b/native-emulation/install.sh
@@ -51,7 +51,7 @@ extract_images () {
     curl -sSL "$IMAGE_URL" -o "${IMAGE}.zip"
   [ -f "${IMAGE}.img" ] || \
     unzip "${IMAGE}.zip"
-  [ -f "${IMAGE}.img" ] || \
+  [ -f "${IMAGE}.img" ] && \
     qemu-img resize -f raw "${IMAGE}.img" 2G
 }
 

--- a/native-emulation/run.sh
+++ b/native-emulation/run.sh
@@ -4,12 +4,12 @@ set -euxo pipefail
 
 readonly IMAGE='2020-08-20-raspios-buster-armhf-lite'
 readonly KERNEL='kernel8.img'
-readonly PTB='bcm2710-rpi-3-b-plus.dtb'
+readonly DTB='bcm2710-rpi-3-b-plus.dtb'
 
 readonly TMP_DIR="${HOME}/qemu_vms_native"
 readonly IMAGE_FILE="${TMP_DIR}/${IMAGE}.img"
 readonly KERNEL_FILE="${TMP_DIR}/${KERNEL}"
-readonly PTB_FILE="${TMP_DIR}/${PTB}"
+readonly DTB_FILE="${TMP_DIR}/${DTB}"
 
 readonly QEMU_SYS='qemu-system-aarch64'
 
@@ -29,7 +29,7 @@ run_qemu () {
     -device 'usb-net,netdev=net0' \
     -netdev 'user,id=net0,hostfwd=tcp::5022-:22' \
     -drive "file=$IMAGE_FILE,index=0,format=raw" \
-    -dtb "$PTB_FILE" \
+    -dtb "$DTB_FILE" \
     -kernel "$KERNEL_FILE" \
     -append 'rw earlyprintk loglevel=8 console=ttyAMA0,115200 dwc_otg.lpm_enable=0 root=/dev/mmcblk0p2 rootdelay=1' \
     -no-reboot \

--- a/native-emulation/run.sh
+++ b/native-emulation/run.sh
@@ -28,7 +28,7 @@ run_qemu () {
     -device usb-kbd \
     -device 'usb-net,netdev=net0' \
     -netdev 'user,id=net0,hostfwd=tcp::5022-:22' \
-    -sd "$IMAGE_FILE" \
+    -drive "file=$IMAGE_FILE,index=0,format=raw" \
     -dtb "$PTB_FILE" \
     -kernel "$KERNEL_FILE" \
     -append 'rw earlyprintk loglevel=8 console=ttyAMA0,115200 dwc_otg.lpm_enable=0 root=/dev/mmcblk0p2 rootdelay=1' \

--- a/native-emulation/run.sh
+++ b/native-emulation/run.sh
@@ -28,7 +28,7 @@ run_qemu () {
     -device usb-kbd \
     -device 'usb-net,netdev=net0' \
     -netdev 'user,id=net0,hostfwd=tcp::5022-:22' \
-    -drive "file=$IMAGE_FILE,index=0,format=raw" \
+    -drive "file=${IMAGE_FILE},index=0,format=raw" \
     -dtb "$DTB_FILE" \
     -kernel "$KERNEL_FILE" \
     -append 'rw earlyprintk loglevel=8 console=ttyAMA0,115200 dwc_otg.lpm_enable=0 root=/dev/mmcblk0p2 rootdelay=1' \

--- a/native-emulation/run.sh
+++ b/native-emulation/run.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-readonly IMAGE='2020-02-13-raspbian-buster-lite'
+readonly IMAGE='2020-08-20-raspios-buster-armhf-lite'
 readonly KERNEL='kernel8.img'
 readonly PTB='bcm2710-rpi-3-b-plus.dtb'
 


### PR DESCRIPTION
In addition, fix the script so that the qemu-image resize actually works properly.  Finally, avoid some startup warnings by changing the image to be in raw mode.